### PR TITLE
Fix compression on files with same-byte blocks

### DIFF
--- a/compress.cpp
+++ b/compress.cpp
@@ -181,7 +181,6 @@ int CompressQuantum(LzCoder *coder, LzTemp *lztemp, MatchLenStorage *mls,
       if (AreAllBytesEqual(src, round_bytes)) {
         float memset_cost = kInvalidCost;
         int n = EncodeArrayU8_Memset(dst, dst_end, src, round_bytes, coder->entropy_opts, coder->speed_tradeoff, coder->platforms, &memset_cost);
-        src += round_bytes;
         dst += n;
         total_cost += memset_cost;
       } else {


### PR DESCRIPTION
The line of code to skip over to the next block to compress runs twice when the `AreAllBytesEqual` test returns true, one on line 184 and another outside the `if` blocks on line 238. This causes issues when compressing files that have blocks of equal-byte data. This PR removes the extra line to fix compression for these files.